### PR TITLE
docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,5 +7,6 @@ WORKDIR /nostalgia_timeline
 COPY . /nostalgia_timeline
 
 RUN pip install -r requirements.txt
+RUN pip install nostalgia_chrome
 
 ENTRYPOINT ["python", "timeline.py" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM python
+
+RUN mkdir /nostalgia_timeline
+
+WORKDIR /nostalgia_timeline
+
+COPY . /nostalgia_timeline
+
+RUN pip install -r requirements.txt
+
+ENTRYPOINT ["python", "timeline.py" ]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,12 @@
+version: "3"
+services:
+  timeline:
+    image: nostalgia_timeline
+    container_name: nostalgia_timeline
+    ports:
+      - 5000:5000
+    volumes:
+      - ~/nostalgia_data:/root/nostalgia_data/
+    restart: always
+    environment: 
+      - FLASK_ENV=development

--- a/timeline.py
+++ b/timeline.py
@@ -140,4 +140,4 @@ def info():
 
 
 if __name__ == "__main__":
-    app.run()
+    app.run(host='0.0.0.0')


### PR DESCRIPTION
Currently broken.

With a `nostalgia_entry.py` that looks like this;

```python
# File contents of ~/nostalgia_data/nostalgia_entry.py below
from nostalgia.sources.chrome_history import WebHistory

web_history = WebHistory.register()
```

The following occurs on GET;

```
nostalgia_timeline | Traceback (most recent call last):
nostalgia_timeline |   File "/usr/local/lib/python3.8/site-packages/flask/app.py", line 2463, in __call__
nostalgia_timeline |     return self.wsgi_app(environ, start_response)
nostalgia_timeline |   File "/usr/local/lib/python3.8/site-packages/flask/app.py", line 2449, in wsgi_app
nostalgia_timeline |     response = self.handle_exception(e)
nostalgia_timeline |   File "/usr/local/lib/python3.8/site-packages/flask_cors/extension.py", line 161, in wrapped_function
nostalgia_timeline |     return cors_after_request(app.make_response(f(*args, **kwargs)))
nostalgia_timeline |   File "/usr/local/lib/python3.8/site-packages/flask/app.py", line 1866, in handle_exception
nostalgia_timeline |     reraise(exc_type, exc_value, tb)
nostalgia_timeline |   File "/usr/local/lib/python3.8/site-packages/flask/_compat.py", line 39, in reraise
nostalgia_timeline |     raise value
nostalgia_timeline |   File "/usr/local/lib/python3.8/site-packages/flask/app.py", line 2446, in wsgi_app
nostalgia_timeline |     response = self.full_dispatch_request()
nostalgia_timeline |   File "/usr/local/lib/python3.8/site-packages/flask/app.py", line 1951, in full_dispatch_request
nostalgia_timeline |     rv = self.handle_user_exception(e)
nostalgia_timeline |   File "/usr/local/lib/python3.8/site-packages/flask_cors/extension.py", line 161, in wrapped_function
nostalgia_timeline |     return cors_after_request(app.make_response(f(*args, **kwargs)))
nostalgia_timeline |   File "/usr/local/lib/python3.8/site-packages/flask/app.py", line 1820, in handle_user_exception
nostalgia_timeline |     reraise(exc_type, exc_value, tb)
nostalgia_timeline |   File "/usr/local/lib/python3.8/site-packages/flask/_compat.py", line 39, in reraise
nostalgia_timeline |     raise value
nostalgia_timeline |   File "/usr/local/lib/python3.8/site-packages/flask/app.py", line 1949, in full_dispatch_request
nostalgia_timeline |     rv = self.dispatch_request()
nostalgia_timeline |   File "/usr/local/lib/python3.8/site-packages/flask/app.py", line 1935, in dispatch_request
nostalgia_timeline |     return self.view_functions[rule.endpoint](**req.view_args)
nostalgia_timeline |   File "/nostalgia_timeline/timeline.py", line 58, in root
nostalgia_timeline |     load_entry()
nostalgia_timeline |   File "/usr/local/lib/python3.8/site-packages/nostalgia/utils.py", line 147, in load_entry
nostalgia_timeline |     import nostalgia_entry
nostalgia_timeline |   File "/root/nostalgia_data/nostalgia_entry.py", line 2, in <module>
nostalgia_timeline |     from nostalgia.sources.chrome_history import WebHistory
nostalgia_timeline |   File "/usr/local/lib/python3.8/site-packages/nostalgia/sources/chrome_history.py", line 6, in <module>
nostalgia_timeline |     import lxml.html
nostalgia_timeline | ModuleNotFoundError: No module named 'lxml'
```